### PR TITLE
ENH: Added geocube.show_versions & cli 'geocube --show-versions'

### DIFF
--- a/docs/geocube.rst
+++ b/docs/geocube.rst
@@ -4,7 +4,13 @@ Core
 make_geocube
 -------------------------
 
-.. automethod:: geocube.api.core.make_geocube
+.. autofunction:: geocube.api.core.make_geocube
+
+
+show_versions
+-------------------------
+
+.. autofunction:: geocube.show_versions
 
 
 exceptions

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,6 +1,10 @@
 History
 =======
 
+0.0.12
+------
+- ENH: Added :func:`geocube.show_versions` and cli `geocube --show-versions` (pull #23)
+
 0.0.11
 ------
 - Drop Python 3.5 Support (issue #12)

--- a/geocube/__init__.py
+++ b/geocube/__init__.py
@@ -5,4 +5,5 @@
 __author__ = """Geocube Contributors"""
 __email__ = "alansnow21@gmail.com"
 
+from geocube._show_versions import show_versions  # noqa
 from geocube._version import __version__  # noqa

--- a/geocube/_show_versions.py
+++ b/geocube/_show_versions.py
@@ -1,0 +1,113 @@
+"""
+Utility methods to print system info for debugging
+
+adapted from :func:`sklearn.utils._show_versions`
+which was adapted from :func:`pandas.show_versions`
+"""
+import importlib
+import platform
+import sys
+
+
+def _get_sys_info():
+    """System information
+    Return
+    ------
+    sys_info : dict
+        system and Python version information
+    """
+    blob = [
+        ("python", sys.version.replace("\n", " ")),
+        ("executable", sys.executable),
+        ("machine", platform.platform()),
+    ]
+
+    return dict(blob)
+
+
+def _get_gdal_info():
+    """Get the GDAL dependency information.
+
+    Returns
+    -------
+    proj_info: dict
+        system GDAL information
+    """
+    import rasterio
+    import fiona
+
+    blob = [
+        ("fiona", fiona.__version__),
+        ("GDAL[fiona]", fiona.__gdal_version__),
+        ("rasterio", rasterio.__version__),
+        ("GDAL[rasterio]", rasterio.__gdal_version__),
+    ]
+
+    return dict(blob)
+
+
+def _get_deps_info():
+    """Overview of the installed version of dependencies
+    Returns
+    -------
+    deps_info: dict
+        version information on relevant Python libraries
+    """
+    deps = [
+        "appdirs",
+        "click",
+        "datacube",
+        "geopandas",
+        "rioxarray",
+        "pyproj",
+        "xarray",
+    ]
+
+    def get_version(module):
+        try:
+            return module.__version__
+        except AttributeError:
+            return module.version
+
+    deps_info = {}
+
+    for modname in deps:
+        try:
+            if modname in sys.modules:
+                mod = sys.modules[modname]
+            else:
+                mod = importlib.import_module(modname)
+            ver = get_version(mod)
+            deps_info[modname] = ver
+        except ImportError:
+            deps_info[modname] = None
+
+    return deps_info
+
+
+def _print_info_dict(info_dict):
+    """Print the information dictionary"""
+    for key, stat in info_dict.items():
+        print("{key:>14}: {stat}".format(key=key, stat=stat))
+
+
+def show_versions():
+    """
+    .. versionadded:: 0.0.12
+
+    Print useful debugging information
+
+    Example
+    -------
+    > python -c "import geocube; geocube.show_versions()"
+
+    """
+    import geocube
+
+    print(f"geocube v{geocube.__version__}\n")
+    print(f"GDAL deps:")
+    _print_info_dict(_get_gdal_info())
+    print("\nPython deps:")
+    _print_info_dict(_get_deps_info())
+    print("\nSystem:")
+    _print_info_dict(_get_sys_info())

--- a/geocube/cli/geocube.py
+++ b/geocube/cli/geocube.py
@@ -6,7 +6,7 @@ import click
 from click import group
 
 import geocube.cli.commands as cmd_modules
-from geocube import __version__
+from geocube import __version__, show_versions
 
 CONTEXT_SETTINGS = {
     "help_option_names": ["-h", "--help"],
@@ -32,6 +32,22 @@ def check_version(ctx, _, value):
     ctx.exit()
 
 
+def cli_show_version(ctx, _, value):
+    """
+    Print debugging version information.
+
+    :param ctx: Application context object (click.Context)
+    :param value: Passed in by Click
+    :return None
+    """
+    if not value or ctx.resilient_parsing:
+        return
+
+    show_versions()
+
+    ctx.exit()
+
+
 @group(context_settings=CONTEXT_SETTINGS)
 @click.option(
     "-v",
@@ -41,6 +57,14 @@ def check_version(ctx, _, value):
     expose_value=False,
     callback=check_version,
     help="Show the current version",
+)
+@click.option(
+    "--show-versions",
+    is_flag=True,
+    is_eager=True,
+    expose_value=False,
+    callback=cli_show_version,
+    help="Show debugging version information",
 )
 def geocube():
     """ Top-level command and entry point into the GeoCube CLI """

--- a/test/unit/cli/test_geocube.py
+++ b/test/unit/cli/test_geocube.py
@@ -1,7 +1,7 @@
 import click
 from mock import MagicMock, patch
 
-from geocube.cli.geocube import check_version
+from geocube.cli.geocube import check_version, cli_show_version
 
 
 @patch("geocube.cli.geocube.__version__", "1.1")
@@ -12,3 +12,15 @@ def test_check_version(capsys):
 
     stdout = capsys.readouterr()[0]
     assert "geocube v1.1" in stdout
+
+
+def test_cli_show_versions(capsys):
+    context = MagicMock(click.Context)
+    context.resilient_parsing = False
+    cli_show_version(context, "str", "str")
+
+    stdout = capsys.readouterr()[0]
+    assert "geocube v" in stdout
+    assert "GDAL deps" in stdout
+    assert "Python deps" in stdout
+    assert "System" in stdout

--- a/test/unit/test_show_versions.py
+++ b/test/unit/test_show_versions.py
@@ -1,0 +1,40 @@
+from geocube import show_versions
+from geocube._show_versions import _get_deps_info, _get_gdal_info, _get_sys_info
+
+
+def test_get_gdal_info():
+    gdal_info = _get_gdal_info()
+    assert "rasterio" in gdal_info
+    assert "GDAL[rasterio]" in gdal_info
+    assert "fiona" in gdal_info
+    assert "GDAL[fiona]" in gdal_info
+
+
+def test_get_sys_info():
+    sys_info = _get_sys_info()
+
+    assert "python" in sys_info
+    assert "executable" in sys_info
+    assert "machine" in sys_info
+
+
+def test_get_deps_info():
+    deps_info = _get_deps_info()
+
+    assert "rioxarray" in deps_info
+    assert "geopandas" in deps_info
+    assert "pyproj" in deps_info
+    assert "xarray" in deps_info
+    assert "datacube" in deps_info
+    assert "click" in deps_info
+    assert "appdirs" in deps_info
+
+
+def test_show_versions_with_proj(capsys):
+    show_versions()
+    out, err = capsys.readouterr()
+    assert "System" in out
+    assert "python" in out
+    assert "GDAL deps" in out
+    assert "geocube" in out
+    assert "Python deps" in out


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Tests added
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

```
$ geocube --show-versions
geocube v0.0.11

GDAL deps:
         fiona: 1.8.9.post2
   GDAL[fiona]: 2.4.4
      rasterio: 1.1.3
GDAL[rasterio]: 2.4.4

Python deps:
       appdirs: 1.4.3
         click: 7.0
      datacube: 1.7
     geopandas: 0.7.0
     rioxarray: 0.0.23
        pyproj: 2.5.0
        xarray: 0.15.0

System:
        python: 3.6.10 | packaged by conda-forge | (default, Mar  5 2020, 10:05:08)  [GCC 7.3.0]
    executable: /home/snowal/miniconda/envs/geocube/bin/python3.6
       machine: Linux-4.15.0-96-generic-x86_64-with-debian-buster-sid

```