### PR TITLE
Add compatibility between datacube and geopandas CRS versions

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -4,6 +4,7 @@ History
 0.0.12
 ------
 - ENH: Added :func:`geocube.show_versions` and cli `geocube --show-versions` (pull #23)
+- Add compatibility between datacube and geopandas CRS versions (pull #24)
 
 0.0.11
 ------


### PR DESCRIPTION
ERROR: https://travis-ci.com/github/corteva/geocube/jobs/318278233

```
       if self.geom is None and self.output_crs:

            geopoly = geometry.Geometry(

                mapping(

>                   box(*vector_data.to_crs(crs._crs.ExportToProj4()).total_bounds)

                ),

                crs=crs,

E               AttributeError: 'CRS' object has no attribute 'ExportToProj4'
```

FIXED: https://travis-ci.com/github/corteva/geocube/builds/159838557 (datacube==1.8.0b5)

Removed pin as only used for testing.

NOTE: Still ignoring appveyor tests