### PR TITLE
LNT: Use black isort profile and remove seed-isort-config

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,6 +1,3 @@
 [settings]
-line_length=88
-multi_line_output=3
-known_third_party=appdirs,click,datacube,dateutil,geopandas,mock,numpy,pandas,pytest,rasterio,rioxarray,scipy,setuptools,shapely,xarray
 known_first_party=geocube,test
-include_trailing_comma=true
+profile=black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,10 +9,6 @@ repos:
         rev: 20.8b1
         hooks:
         -   id: black
-    -   repo: https://github.com/asottile/seed-isort-config
-        rev: v2.2.0
-        hooks:
-        -   id: seed-isort-config
     -   repo: https://github.com/timothycrosley/isort
         rev: 5.6.4
         hooks:


### PR DESCRIPTION
- https://pycqa.github.io/isort/docs/configuration/profiles/
- https://pycqa.github.io/isort/docs/upgrade_guides/5.0.0/
> If you have a step in your precommit called seed-isort-config or similar, it is highly recommend that you remove this.