### PR TITLE
TST: Replace mock test dependency with unittest.mock

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ requirements = [
     "pyproj>=2",
 ]
 
-test_requirements = ["pytest>=3.6", "pytest-cov", "mock"]
+test_requirements = ["pytest>=3.6", "pytest-cov"]
 doc_requirements = ["sphinx-click==1.1.0", "nbsphinx", "sphinx_rtd_theme"]
 
 extras_require = {

--- a/test/unit/cli/commands/test_make_geocube.py
+++ b/test/unit/cli/commands/test_make_geocube.py
@@ -1,10 +1,10 @@
 import os
+from unittest.mock import patch
 
 import numpy
 import pytest
 import xarray
 from click.testing import CliRunner
-from mock import patch
 
 from geocube.cli.geocube import geocube
 from test.conftest import TEST_COMPARE_DATA_DIR, TEST_INPUT_DATA_DIR

--- a/test/unit/cli/test_geocube.py
+++ b/test/unit/cli/test_geocube.py
@@ -1,5 +1,6 @@
+from unittest.mock import MagicMock, patch
+
 import click
-from mock import MagicMock, patch
 
 from geocube.cli.geocube import check_version, cli_show_version
 

--- a/test/unit/test_unit_logger.py
+++ b/test/unit/test_unit_logger.py
@@ -1,4 +1,4 @@
-from mock import patch
+from unittest.mock import patch
 
 from geocube.logger import get_logger, log_to_console, log_to_file
 


### PR DESCRIPTION
unittest.mock was added to the standard library in Python 3.3.
