### PR TITLE
REF: remove unnecessary shapely.geometry.mapping in rasterize_image

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,7 @@ History
 
 Latest
 ------
+- REF: remove unnecessary shapely.geometry.mapping in rasterize_image (#80)
 
 0.0.18
 ------

--- a/geocube/rasterize.py
+++ b/geocube/rasterize.py
@@ -7,7 +7,6 @@ import pandas
 import rasterio.features
 from rasterio.enums import MergeAlg
 from scipy.interpolate import Rbf, griddata
-from shapely.geometry import mapping
 
 from geocube.logger import get_logger
 
@@ -76,7 +75,7 @@ def rasterize_image(
                 data_values, geometry_array
             )
         image = rasterio.features.rasterize(
-            zip(geometry_array.apply(mapping).values, data_values),
+            zip(geometry_array.values, data_values),
             out_shape=(geobox.height, geobox.width),
             transform=geobox.affine,
             fill=fill,


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Fully documented, including `docs/history.rst` for all changes and `docs/geocube.rst` for new API
