### PR TITLE
BUG: Updated logic to skip rasterizing strings for numpy 1.22+

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,7 +3,7 @@ History
 
 Latest
 -------
-
+- BUG: Updated logic to skip rasterizing strings for numpy 1.22+ (issue #88)
 
 0.1.0
 ------


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #88
 - [x] Fully documented, including `docs/history.rst` for all changes and `docs/geocube.rst` for new API
