### PR TITLE
MNT: corrections to setup.cfg; use "pytest"; add "make dist" target

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -68,7 +68,7 @@ jobs:
         shell: bash
         run: |
           source activate test
-          py.test --cov-report term-missing --cov=geocube --cov-report xml
+          pytest --cov-report term-missing --cov=geocube --cov-report xml
 
       - name: Test Build docs
         shell: bash

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
         rev: 5.10.1
         hooks:
         -   id: isort
-            args: [setup.py, rioxarray/, test/, docs/]
+            args: [rioxarray/, test/, docs/]
     -   repo: https://github.com/asottile/blacken-docs
         rev: v1.12.1
         hooks:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -91,7 +91,7 @@ Ready to contribute? Here's how to set up `geocube` for local development.
 
     $ flake8 geocube/ test/
     $ black --check .
-    $ py.test
+    $ pytest
 
 7. Commit your changes and push your branch to GitLab::
 
@@ -117,4 +117,4 @@ Tips
 
 To run a subset of tests::
 
-$ py.test test.test_geocube
+$ pytest test/unit/cli/test_geocube.py::test_check_version

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ pylint:
 	pylint --load-plugins tests.linter --disable=I,E,W,R,C,F --enable C9999,C9998 tests/
 
 test: ## run tests quickly with the default Python
-	py.test
+	pytest
 
 docs: ## generate Sphinx HTML documentation, including API docs
 	$(MAKE) -C docs clean
@@ -72,12 +72,16 @@ docs-browser: docs ## generate Sphinx HTML documentation, including API docs
 	$(BROWSER) docs/_build/html/index.html
 
 release: dist ## package and upload a release
+	twine check --strict dist/*
 	twine upload dist/*
+
+dist: clean  ## builds source and wheel package
+	python -m build
 
 report: install-dev coverage ## clean, install development version, run all tests, produce coverage report
 
 install: clean ## install the package to the active Python's site-packages
-	python setup.py install
+	pip install .
 
 install-dev: clean ## install development version to active Python's site-packages
 	pip install -e .[all]

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,11 +2,13 @@
 author = geocube Contributors
 author_email = alansnow21@gmail.com
 name = geocube
+version = attr: geocube.__version__
 description = Tool to convert geopandas vector data into rasterized xarray data.
 keywords = geocube, GDAL, rasterize, vector
 long_description = file: README.rst
+long_description_content_type = text/x-rst
 license = BSD license
-license_file = LICENSE
+license_files = LICENSE
 platform = any
 classifiers =
     Development Status :: 4 - Beta
@@ -73,6 +75,3 @@ all =
     %(doc)s
     %(test)s
     %(dev)s
-
-[bdist_wheel]
-universal = 1

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,4 @@
 
 from setuptools import setup
 
-from geocube import __version__
-
-setup(version=__version__)
+setup()


### PR DESCRIPTION
There are several corrections and improvements related to building geocube bundled in this PR:

- `setup.cfg`:
  - remove `bdist_universal` option, which was used when building packages that are compatible with Python 2 and 3 (e.g. `python -m build` wrote `geocube-0.3.2.dev0-py2.py3-none-any.whl`)
  - Use `license_files` to side-step warning in `python -m build`
  - Specify `long_description_content_type` to side-step warning in `twine check dist/*`
  - Add dynamic version from attribute
- `setup.py` is now a basic shim file, and does nothing custom; it might be removed at some point
- Use `pytest` command instead of `py.test` ([ref](https://stackoverflow.com/a/41893170/))
- Add `make dist` target, which was referenced in the Makefile
- Add `twine check --strict dist/*` before uploading release -- although I suspect this is not actually used, as I don't see any `.whl` files on PyPI