### PR TITLE
BUG: Handle geopandas CRS check in vectorxarray

### DIFF
--- a/geocube/xarray_extensions/vectorxarray.py
+++ b/geocube/xarray_extensions/vectorxarray.py
@@ -23,7 +23,7 @@ def from_geodataframe(in_geodataframe):
     # writing CRS
     geox.rio._x_dim = "x"
     geox.rio._y_dim = "y"
-    geox.rio.write_crs(geodf.crs, inplace=True)
+    geox.rio.write_crs(in_geodataframe.crs, inplace=True)
     geox.rio._x_dim = None
     geox.rio._y_dim = None
     return geox


### PR DESCRIPTION
https://github.com/corteva/geocube/actions/runs/3363188612/jobs/5575985132
```
AttributeError: You are calling a geospatial method on the GeoDataFrame, but the active geometry column ('geometry') is not present. 
There are no existing columns with geometry data type. You can add a geometry column as the active geometry column with df.set_geometry.
```

Seems that `set_index("geometry")` breaks the check.