### PR TITLE
BUG: Fix conversion to datetime64[ns]

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,7 @@ History
 
 Latest
 -------
+- BUG: Fix conversion to datetime64[ns] (pull #143)
 
 0.4.0
 -------

--- a/geocube/vector_to_cube.py
+++ b/geocube/vector_to_cube.py
@@ -152,9 +152,12 @@ class VectorToCube:
 
         # convert to datetime
         for datetime_measurement in self._datetime_measurements:  # type: ignore
-            vector_data[datetime_measurement] = pandas.to_datetime(
-                vector_data[datetime_measurement]
-            ).astype("datetime64[ns]")
+            vector_data[datetime_measurement] = (
+                pandas.to_datetime(vector_data[datetime_measurement])
+                .dt.tz_convert("UTC")
+                .dt.tz_localize(None)
+                .astype("datetime64[ns]")
+            )
 
         # get categorical enumerations if they exist
         self._categorical_enums = {}


### PR DESCRIPTION
```
E           TypeError: Cannot use .astype to convert from timezone-aware dtype to timezone-naive dtype. Use obj.tz_localize(None) or obj.tz_convert('UTC').tz_localize(None) instead.
```