### PR TITLE
BUG: Update minimize dtype for int64 & int8 support

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,7 @@ History
 
 Latest
 -------
+- BUG: Update minimize dtype for int64 & int8 support (issue #139)
 
 0.4.2
 -------

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     click>=6.0
     geopandas>=0.7
     odc_geo
-    rasterio
+    rasterio>=1.3
     rioxarray>=0.4
     scipy
     xarray>=0.17

--- a/test/integration/api/test_core_integration.py
+++ b/test/integration/api/test_core_integration.py
@@ -15,6 +15,7 @@ from shapely.wkt import loads
 from geocube.api.core import make_geocube
 from geocube.exceptions import VectorDataError
 from geocube.rasterize import (
+    _INT8_SUPPORTED,
     rasterize_image,
     rasterize_points_griddata,
     rasterize_points_radial,
@@ -101,7 +102,7 @@ def test_make_geocube__categorical(input_geodata, tmpdir):
         categorical_enums={"soil_type": ("sand", "silt", "clay")},
         fill=-9999.0,
     )
-    assert out_grid.soil_type.dtype.name == "int16"
+    assert out_grid.soil_type.dtype.name == "int8" if _INT8_SUPPORTED else "int16"
 
     # test writing to netCDF
     out_grid.to_netcdf(
@@ -451,7 +452,7 @@ def test_make_geocube__group_by__categorical(input_geodata, tmpdir):
         fill=-9999.0,
     )
 
-    assert out_grid.soil_type.dtype.name == "int16"
+    assert out_grid.soil_type.dtype.name == "int8" if _INT8_SUPPORTED else "int16"
     # test writing to netCDF
     out_grid.to_netcdf(
         tmpdir.mkdir("make_geocube_soil") / "soil_grid_group_categorical.nc"
@@ -816,7 +817,7 @@ def test_make_geocube__custom_rasterize_function__filter_null(
         ("uint16", float("NaN"), "float32"),
         ("int32", 0, "int32"),
         ("int32", float("NaN"), "float64"),
-        ("int64", 0, "float64"),
+        ("int64", 0, "int64"),
         ("int64", float("NaN"), "float64"),
     ],
 )


### PR DESCRIPTION
 - [x] Closes #139

geocube supports GDAL 3.5+