### PR TITLE
Remove numpy<2 pin

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,7 +41,7 @@ jobs:
           create-args: >-
             python=${{ matrix.python-version }}
             geopandas
-            numpy<2
+            numpy
             netcdf4
             odc-geo
             pandoc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "scipy",
     "xarray>=0.17",
     "pyproj>=2",
-    "numpy>=1.20,<2",
+    "numpy>=1.20",
 ]
 
 [project.urls]


### PR DESCRIPTION
Incompatibility with numpy=2.0 should have been fixed in rasterio 1.4.0 (https://github.com/rasterio/rasterio/pull/3109).

This will allow us to keep `geocube` in pangeo-docker-image which is upgrading to numpy 2.0 (xref https://github.com/pangeo-data/pangeo-docker-images/pull/584#discussion_r1782867487), once there is a new `geocube` release on conda-forge.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Supersedes #175
 - [ ] Tests added
 - [ ] Fully documented, including `docs/history.rst` for all changes and `docs/geocube.rst` for new API
