### PR TITLE
LNT: Ignore return value mypy error

### DIFF
--- a/geocube/rasterize.py
+++ b/geocube/rasterize.py
@@ -23,7 +23,7 @@ def _is_numeric(data_values: NDArray) -> bool:
     """
     Check if array data type is numeric.
     """
-    return numpy.issubdtype(data_values.dtype.type, numpy.number)
+    return numpy.issubdtype(data_values.dtype.type, numpy.number)  # type: ignore[return-value]
 
 
 def _remove_missing_data(


### PR DESCRIPTION
This is the error:
```
python -m mypy geocube
geocube/rasterize.py:26: error: Incompatible return value type (got "numpy.bool[builtins.bool]", expected "builtins.bool")  [return-value]
```

The function is using the builtin issubclass method internally.
```python
>>> import numpy
>>> res = numpy.issubdtype("int32", numpy.number)
>>> res
True
>>> type(res)
<class 'bool'>
>>> numpy.bool_(False)
np.False_
>>> type(numpy.bool_(False))
<class 'numpy.bool'>
```