### PR TITLE
BUG: Add datacube 1.9+ geobox compatibility

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,7 @@ History
 
 Latest
 ------
+- BUG: Add datacube 1.9+ geobox compatibility (#185)
 
 0.7.0
 ------

--- a/geocube/geo_utils/geobox.py
+++ b/geocube/geo_utils/geobox.py
@@ -174,7 +174,12 @@ class GeoBoxMaker:
             ), "'like' and 'resolution' are not supported together"
             assert self.align is None, "'like' and 'align' are not supported together"
             try:
-                geobox = self.like.geobox
+                try:
+                    # datacube 1.9+
+                    geobox = self.like.odc.geobox
+                except AttributeError:
+                    # datacube <= 1.8
+                    geobox = self.like.geobox
             except (AttributeError, ValueError):
                 geobox = geobox_from_rio(self.like)
             return geobox


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #185
 - [x] Fully documented, including `docs/history.rst` for all changes and `docs/geocube.rst` for new API
