### PR TITLE
MNT: improve licence metadata (PEP 639), remove setup.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [build-system]
-# Minimum requirements for the build system to execute.
-requires = ["setuptools", "wheel"]
+requires = ["setuptools>77"]
 
 [project]
 name = "geocube"
@@ -15,12 +14,11 @@ keywords = [
     "vector",
 ]
 readme = "README.rst"
-license = {text = "BSD-3-Clause"}
+license = "BSD-3-Clause"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Natural Language :: English",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Topic :: Scientific/Engineering :: GIS",
     "Programming Language :: Python",

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,0 @@
-"""The setup script."""
-
-from setuptools import setup
-
-setup()


### PR DESCRIPTION
This PR has a few project maintenance aims:

- Improve license metadata (see [PEP 639](https://peps.python.org/pep-0639/)):
  - Change licence to a simpler string attribute with a valid SPDX identifier; this clears up a deprecation warning while building with recent setuptools
  - Remove licence classifier, which is deprecated
- Change build-system requirements to specify at least [v77](https://setuptools.pypa.io/en/stable/history.html#v77-0-0) to read new licence metadata. Also "wheel" does not need to be specified anymore (this change happened ages ago).
- Remove setup.py, since it is not needed or referenced anywhere.